### PR TITLE
New keys for mod descs in Mod Menu (lang files) + revert .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # gradle
 
-gradle
-gradlew
 .gradle/
 build/
 out/

--- a/src/main/resources/assets/block-entity-extended-rendering/lang/en_us.json
+++ b/src/main/resources/assets/block-entity-extended-rendering/lang/en_us.json
@@ -1,5 +1,8 @@
 {
   "beer.option.distance": "Block Entity Render Distance",
   "beer.text.apply": "Apply",
-  "beer.screen.config": "Block Entity Enhanced Rendering config"
+  "beer.screen.config": "Block Entity Enhanced Rendering config",
+
+  "modmenu.summaryTranslation.block-entity-extended-rendering": "This mod allows you to increase the render distance of block entities.",
+  "modmenu.descriptionTranslation.block-entity-extended-rendering": "This mod allows you to increase the render distance of block entities."
 }

--- a/src/main/resources/assets/block-entity-extended-rendering/lang/ru_ru.json
+++ b/src/main/resources/assets/block-entity-extended-rendering/lang/ru_ru.json
@@ -1,5 +1,8 @@
 {
-  "beer.option.distance": "Дистанция прорисовк блоков-сущностей",
+  "beer.option.distance": "Дистанция прорисовки блоков-сущностей",
   "beer.text.apply": "Применить",
-  "beer.screen.config": "Настройки Block Entity Enhanced Rendering"
+  "beer.screen.config": "Настройки Block Entity Enhanced Rendering",
+
+  "modmenu.summaryTranslation.block-entity-extended-rendering": "Этот мод позволяет увеличить дистанцию прорисовки блоков-сущностей.",
+  "modmenu.descriptionTranslation.block-entity-extended-rendering": "Этот мод позволяет увеличить дистанцию прорисовки блоков-сущностей."
 }

--- a/src/main/resources/assets/block-entity-extended-rendering/lang/zh_cn.json
+++ b/src/main/resources/assets/block-entity-extended-rendering/lang/zh_cn.json
@@ -1,5 +1,8 @@
 {
   "beer.option.distance": "方块实体渲染距离",
   "beer.text.apply": "应用",
-  "beer.screen.config": "方块实体增强渲染配置"
+  "beer.screen.config": "方块实体增强渲染配置",
+
+  "modmenu.summaryTranslation.block-entity-extended-rendering": "This mod allows you to increase the render distance of block entities.",
+  "modmenu.descriptionTranslation.block-entity-extended-rendering": "This mod allows you to increase the render distance of block entities."
 }


### PR DESCRIPTION
New keys:
- `modmenu.summaryTranslation.block-entity-extended-rendering` is a short description;
- `modmenu.descriptionTranslation.block-entity-extended-rendering` is a long description.

About reverting .gitignore: I realized that building a Gradle wrapper by yourself is not comfortable for some people, so i decided to remove ignore of `gradle/` folder and `gradlew` file.